### PR TITLE
Adds `integer` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ populartimes("ChIJEVBPhRQtTIYR9Qn5LawiZIs",{fillMissing: true}).then(out => cons
 
 Expects `boolean`.
 
-Fills in missing hours in the array. 
+Converts times to military time (24hr) format. 
 
 ##### Example
 

--- a/README.md
+++ b/README.md
@@ -232,12 +232,7 @@ populartimes("ChIJEVBPhRQtTIYR9Qn5LawiZIs",{fillMissing: true, militaryTime: tru
   saturday: [
     { percent: '0%', hour: '0' },
     { percent: '0%', hour: '1' },
-    { percent: '0%', hour: '2' },
-    { percent: '0%', hour: '3' },
-    { percent: '0%', hour: '4' },
-    { percent: '0%', hour: '5' },
-    { percent: '0%', hour: '6' },
-    { percent: '0%', hour: '7' },
+    ....
     { percent: '23%', hour: '8' },
     { percent: '39%', hour: '9' },
     { percent: '55%', hour: '10' },
@@ -248,11 +243,35 @@ populartimes("ChIJEVBPhRQtTIYR9Qn5LawiZIs",{fillMissing: true, militaryTime: tru
     { percent: '77%', hour: '15' },
     { percent: '65%', hour: '16' },
     { percent: '48%', hour: '17' },
-    { percent: '0%', hour: '18' },
-    { percent: '0%', hour: '19' },
-    { percent: '0%', hour: '20' },
-    { percent: '0%', hour: '21' },
-    { percent: '0%', hour: '22' },
-    { percent: '0%', hour: '23' }
+    ....
+  ]
+```
+
+#### integer (default: `false`)
+
+Expects `boolean`.
+
+Converts string values into integers. The percentage value will be converted to a value between `0` and `100`.
+
+##### Example
+
+```
+populartimes("ChIJEVBPhRQtTIYR9Qn5LawiZIs",{militaryTime: true, integer: true}).then(out => console.log(out));
+```
+
+```
+  saturday: [
+    ....
+    { percent: 23, hour: 8 },
+    { percent: 39, hour: 9 },
+    { percent: 55, hour: 10 },
+    { percent: 68, hour: 11 },
+    { percent: 76, hour: 12 },
+    { percent: 80, hour: 13 },
+    { percent: 81, hour: 14 },
+    { percent: 77, hour: 15 },
+    { percent: 65, hour: 16 },
+    { percent: 48, hour: 17 },
+    ....
   ]
 ```

--- a/index.js
+++ b/index.js
@@ -55,7 +55,8 @@ async function getPopularTimes(placeId, options) {
     // set options
     let defaultOptions = {
         fillMissing: false,
-        militaryTime: false
+        militaryTime: false,
+        integer: true
     };
     options = { ...defaultOptions, ...options };
     // get raw html
@@ -125,10 +126,17 @@ async function getPopularTimes(placeId, options) {
                 j++;
             }
         }
+        // handles integer option
+        if(options.integer) {
+            for(let hoursObject of hoursInDay) {
+                hoursObject.hour = parseInt(hoursObject.hour);
+                hoursObject.percent = parseInt(hoursObject.percent.replace('%'))
+            }
+        };
         out[getDayName(i)] = hoursInDay;
         i++;
     }
     return out;
 }
 
-getPopularTimes('ChIJaSv_6gaZ4jARnbiUVn6Z_YY', { fillMissing: true, militaryTime: true }).then(out => console.log(out));
+getPopularTimes('ChIJaSv_6gaZ4jARnbiUVn6Z_YY', { fillMissing: true, militaryTime: true, integer: true }).then(out => console.log(out));

--- a/index.js
+++ b/index.js
@@ -50,8 +50,7 @@ function convertTo24(hoursObject) {
     }
 }
 
-// module.exports = async 
-async function getPopularTimes(placeId, options) {
+module.exports = async function getPopularTimes(placeId, options) {
     // set options
     let defaultOptions = {
         fillMissing: false,
@@ -91,7 +90,6 @@ async function getPopularTimes(placeId, options) {
                 }
             }
         };
-
         let j = 0;
         for (let hour of hours) {
             let hr = hour.getAttribute("aria-label");
@@ -138,5 +136,3 @@ async function getPopularTimes(placeId, options) {
     }
     return out;
 }
-
-getPopularTimes('ChIJaSv_6gaZ4jARnbiUVn6Z_YY', { fillMissing: true, militaryTime: true, integer: true }).then(out => console.log(out));


### PR DESCRIPTION
- Adds option for converting number values (`percentage` & `hour`) into integers
- Removes debugging
- Fixes typo

Example input:

```
populartimes("ChIJEVBPhRQtTIYR9Qn5LawiZIs",{militaryTime: true, integer: true}).then(out => console.log(out));
```

Example output:

```
  saturday: [
    ....
    { percent: 23, hour: 8 },
    { percent: 39, hour: 9 },
    { percent: 55, hour: 10 },
    { percent: 68, hour: 11 },
    { percent: 76, hour: 12 },
    { percent: 80, hour: 13 },
    { percent: 81, hour: 14 },
    { percent: 77, hour: 15 },
    { percent: 65, hour: 16 },
    { percent: 48, hour: 17 },
    ....
  ]
```