### PR TITLE
Fixes bug when there are no hours

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,8 @@ module.exports = async function getPopularTimes(placeId, options) {
                     currently: parts[1],
                     usually: parts[4]
                 }
+            } if(parts.length < 5) {
+                // if no hours, do nothing
             } else {
                 let percent = parts[0];
                 let hour = parts[3];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "populartimes.js",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Get the popular times of a place by scraping Google Maps.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When a business is closed on a single day, it would sometimes return an error since the `parts` array would be one item short.

Example:
![image](https://user-images.githubusercontent.com/22304763/91519823-86af3300-e8a8-11ea-84ad-a642ee8d3103.png)

Fixes the issue by returning `[]` when parts.length < 5.