### PR TITLE
Enables passing puppeteer options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,15 @@ populartimes("ChIJEVBPhRQtTIYR9Qn5LawiZIs",{militaryTime: true, integer: true}).
     ....
   ]
 ```
+
+#### puppeteerOptions (default: {}`)
+
+Expects an `object`.
+
+Passes options to the puppeteer module. For example, when deploying to heroku, you can set pass options to puppeteer to use `no-sandbox` mode.
+
+##### Example
+
+```
+populartimes("ChIJEVBPhRQtTIYR9Qn5LawiZIs",{puppeteerOptions: { headless: true, args:['--no-sandbox', '--disable-setuid-sandbox'] }})
+```

--- a/index.js
+++ b/index.js
@@ -20,8 +20,11 @@ function getDayName(index) {
     return days[index];
 }
 
-async function sendRequest(htmlUrl) {
-    const browser = await puppeteer.launch();
+async function sendRequest(htmlUrl, puppeteerOptions) {
+    let defaultPuppeteerOptions = {};
+    puppeteerOptions = { ...defaultPuppeteerOptions, ...puppeteerOptions }
+
+    const browser = await puppeteer.launch(puppeteerOptions);
     const page = await browser.newPage();
 
     await page.setRequestInterception(true);
@@ -55,11 +58,12 @@ module.exports = async function getPopularTimes(placeId, options) {
     let defaultOptions = {
         fillMissing: false,
         militaryTime: false,
-        integer: true
+        integer: true,
+        puppeteerOptions: {}
     };
     options = { ...defaultOptions, ...options };
     // get raw html
-    const rawData = await sendRequest(getHtmlUrl(placeId));
+    const rawData = await sendRequest(getHtmlUrl(placeId), options.puppeteerOptions);
     // parse html
     const body = new JSDOM(rawData);
     // get days of the week
@@ -99,7 +103,7 @@ module.exports = async function getPopularTimes(placeId, options) {
                     currently: parts[1],
                     usually: parts[4]
                 }
-            } if(parts.length < 5) {
+            } if (parts.length < 5) {
                 // if no hours, do nothing
             } else {
                 let percent = parts[0];
@@ -127,8 +131,8 @@ module.exports = async function getPopularTimes(placeId, options) {
             }
         }
         // handles integer option
-        if(options.integer) {
-            for(let hoursObject of hoursInDay) {
+        if (options.integer) {
+            for (let hoursObject of hoursInDay) {
                 hoursObject.hour = parseInt(hoursObject.hour);
                 hoursObject.percent = parseInt(hoursObject.percent.replace('%'))
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "populartimes.js",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Get the popular times of a place by scraping Google Maps.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Ran into an issue with using this on heroku. Ended up having to pass an options object to puppeteer.

This PR allows users to pass an options object to puppeteer via `populartimes(place_id ,{options})`.

