### PR TITLE
Bug fix for "current" hours & 12am military time

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "populartimes.js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Get the popular times of a place by scraping Google Maps.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes two bugs:

- Fixes a bug with converting the time 12AM to military time.
- Fixes a bug with pulling the current popular time into the array data.  
  - Google outputs the current time as ["Currently", "10%", "busy,", "usually", "13%", "busy","."]. This fix uses a hacky workaround for pulling the correct time into the array.