### PR TITLE
Fixes military times and adds more debugging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ https://www.scraperapi.com/documentation/
 {
   engine: "scraperapi",
   config: {
-    apikey: "your_scraper_api_key",
+    apikey: "your_scraper_api_key",   // required. Sign up at ScraperAPI.io
+    google_places_api_key: "google_places_api_key",   // required. Google API key requires places permissions
     render: true  // optional, defaults to true
   }
 }
@@ -312,6 +313,21 @@ populartimes("ChIJEVBPhRQtTIYR9Qn5LawiZIs",{militaryTime: true, integer: true}).
     { percent: 48, hour: 17 },
     ....
   ]
+```
+
+#### debug (default: `false`)
+
+Outputs debugging information.
+
+##### Example
+
+```
+populartimes("ChIJEVBPhRQtTIYR9Qn5LawiZIs",{debug: true}).then(out => console.log(out));
+```
+
+```
+output is:
+{}
 ```
 
 ## Development

--- a/index.js
+++ b/index.js
@@ -109,9 +109,11 @@ async function sendRequest(htmlUrl, scraperSettings) {
 
 function convertTo24(hoursObject) {
     let { percent, hour, meridiem } = hoursObject;
-    if ((hour == '12' && meridiem == 'AM')) {
+    meridiem = meridiem.toLowerCase()
+    
+    if ((hour == '12' && meridiem == 'am')) {
         return { percent, hour: '0' }
-    } else if ((hour == '12' || meridiem != 'PM')) {
+    } else if ((hour == '12' || meridiem != 'pm')) {
         return { percent, hour }
     } else if (hour !== '12') {
         hour = (parseInt(hour) + 12).toString();
@@ -183,11 +185,11 @@ module.exports = async function getPopularTimes(placeId, functionOptions) {
                 // if not 24hour format, use 12hr format by default
                 for (let d = 0; d < 24; d++) {
                     if (d < 12) {
-                        hoursInDay.push({ percent: '0%', hour: d.toString(), meridiem: 'AM' })
+                        hoursInDay.push({ percent: '0%', hour: d.toString(), meridiem: 'am' })
                     } else if (d === 12) {
-                        hoursInDay.push({ percent: '0%', hour: d.toString(), meridiem: 'PM' })
+                        hoursInDay.push({ percent: '0%', hour: d.toString(), meridiem: 'pm' })
                     } else if (d > 12) {
-                        hoursInDay.push({ percent: '0%', hour: (d - 12).toString(), meridiem: 'PM' })
+                        hoursInDay.push({ percent: '0%', hour: (d - 12).toString(), meridiem: 'pm' })
                     }
                 }
             }
@@ -222,10 +224,10 @@ module.exports = async function getPopularTimes(placeId, functionOptions) {
                 } else {
                     percent = parts[4];
                     hour = (parseInt(hoursTracker) + 1).toString();
-                    if (hoursTracker === '11' && meridiemTracker === 'AM') {
-                        meridiem = 'PM'
-                    } else if (hoursTracker === '11' && meridiemTracker === 'PM') {
-                        meridiem = 'AM'
+                    if (hoursTracker === '11' && meridiemTracker === 'am') {
+                        meridiem = 'pm'
+                    } else if (hoursTracker === '11' && meridiemTracker === 'pm') {
+                        meridiem = 'am'
                     } else {
                         meridiem = meridiemTracker
                     }

--- a/index.js
+++ b/index.js
@@ -58,7 +58,6 @@ async function sendRequest(htmlUrl, scraperSettings) {
         // validation
         if (!config.apikey) {
             let error = 'Error: ScraperAPI key is missing. Please check the populartimes.js documentation'
-            console.error(error)
             return error
         }
 
@@ -75,8 +74,8 @@ async function sendRequest(htmlUrl, scraperSettings) {
                 return data
             }
         }).catch(err => {
-            console.log(err.status)
-            console.log(err.statusText)
+            console.error(err.status)
+            console.error(err.statusText)
             return err
         })
     }
@@ -134,7 +133,6 @@ module.exports = async function getPopularTimes(placeId, functionOptions) {
         }
     };
     options = { ...options, ...functionOptions };
-
     // get raw html
     const rawData = await sendRequest(getHtmlUrl(placeId), options.scraperSettings);
     // parse html
@@ -154,7 +152,6 @@ module.exports = async function getPopularTimes(placeId, functionOptions) {
             console.error(`Did not find a place name using place_id: ${place_id}`)
             return {}
         } else {
-            console.log(placeName)
             days = body.window.document.querySelectorAll(`div[aria-label="Popular times at ${placeName}"] > div:last-of-type > div`);
         }
     }
@@ -267,7 +264,12 @@ module.exports = async function getPopularTimes(placeId, functionOptions) {
         i++;
     }
 
-    console.log('output is:')
-    console.log(out)
+    if(!!options.debug) {
+        console.log('PlaceID: ',placeId)
+        console.log('Options selected:')
+        console.log(options)
+        console.log('output: ')
+        console.log(out)
+    }
     return out;
 }

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ async function sendRequest(htmlUrl, scraperSettings) {
         // continue
         axiosOptions = {
             method: 'get',
-            url: `http://api.scraperapi.com?api_key=${config.apikey}&render=${config.render}&country_code=us&url=${encodeURIComponent(htmlUrl + "&region=us&language=us")}`
+            url: `http://api.scraperapi.com?api_key=${config.apikey}&render=${config.render}&country_code=us&url=${encodeURIComponent(htmlUrl + "&region=us&language=us&hl=en")}`
         }
 
         return axios(axiosOptions).then(data => {

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ async function sendRequest(htmlUrl, scraperSettings) {
 function convertTo24(hoursObject) {
     let { percent, hour, meridiem } = hoursObject;
     meridiem = meridiem.toLowerCase()
-    
+
     if ((hour == '12' && meridiem == 'am')) {
         return { percent, hour: '0' }
     } else if ((hour == '12' || meridiem != 'pm')) {
@@ -270,8 +270,16 @@ module.exports = async function getPopularTimes(placeId, functionOptions) {
         console.log('PlaceID: ',placeId)
         console.log('Options selected:')
         console.log(options)
+        if(options.scraperSettings.engine.toLowerCase() === 'scraperapi') {
+            console.log("ScraperAPI URL:")
+            console.log(`http://api.scraperapi.com?api_key=${options.scraperSettings.config.apikey}&render=${options.scraperSettings.config.render}&country_code=us&url=${encodeURIComponent(`https://www.google.com/maps/place/?q=place_id:${placeId}` + "&region=us&language=us&hl=en")}`)
+        }
         console.log('output: ')
         console.log(out)
+    }
+    if(!out) {
+        console.error('Problem running populartimes.js')
+        return null
     }
     return out;
 }

--- a/tests.js
+++ b/tests.js
@@ -3,7 +3,7 @@ const getPopularTimes = require('./index');
 testFunction = async () => {
     // testing scraperapi
     console.log('Testing scraperAPI first')
-    console.log(await getPopularTimes('ChIJc5KGoHXDyIARjRvuzlguft8', {
+    await getPopularTimes('ChIJc5KGoHXDyIARjRvuzlguft8', {
         scraperSettings: {
             engine: "scraperapi",
             config: {
@@ -12,16 +12,16 @@ testFunction = async () => {
                 google_places_api_key: "your_places_api_key"
             }
         }
-    }))
-    
+    })
+
     // testing puppeteer
     console.log('Testing puppeteer next');
-    console.log(await getPopularTimes('ChIJc5KGoHXDyIARjRvuzlguft8', {
+    await getPopularTimes('ChIJc5KGoHXDyIARjRvuzlguft8', {
         scraperSettings: {
             engine: "puppeteer",
             config: {}
         }
-    }))
-} 
+    })
+}
 
 testFunction();


### PR DESCRIPTION
- Fixes military time mixup caused by AM/PM casing
- Adds a console debugging option (`{debug: true}`)
- Fixes a readme typo for using ScraperAPI
- _Hopefully_ fixes ScraperAPI scraping popular times in other languages  
  - For context, sometimes ScraperAPI will crawl the site in German or Japanese, messing up the query selectors