### PR TITLE
Fixes quotes in placenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,13 @@ module.exports = async function getPopularTimes(placeId, functionOptions) {
         console.error(`Did not find a place name using place_id: ${place_id}`)
         return {}
     } else {
+        if(placeName.indexOf(`"`) > -1) {
+            placeName = placeName.replace(/\"/g,'\\"')
+        }
         days = body.window.document.querySelectorAll(`div[aria-label="Popular times at ${placeName}"] > div:last-of-type > div`);
+        if(!!days) {
+            
+        }
     }
 
     // loop through the days

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "populartimes.js",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Get the popular times of a place by scraping Google Maps.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If a place had a `"` in the name, it would break the search.

This PR fixes that issue by escaping `"` before performing a search.